### PR TITLE
no more windows support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:


### PR DESCRIPTION
Keep getting this error on actions and it's causing me to have to keep re-running builds, which is annoying

```
_tkinter.TclError: Can't find a usable tk.tcl in the following directories: 
    C:/hostedtoolcache/windows/Python/3.12.9/x64/tcl/tcl8.6/tk8.6 C:/hostedtoolcache/windows/Python/3.12.9/x64/tcl/tk8.6 C:/hostedtoolcache/windows/Python/3.12.9/lib/tk8.6 C:/hostedtoolcache/windows/Python/3.12.9/lib/tk8.6 C:/hostedtoolcache/windows/Python/lib/tk8.6 C:/hostedtoolcache/windows/Python/3.12.9/library

C:/hostedtoolcache/windows/Python/3.12.9/x64/tcl/tk8.6/tk.tcl: couldn't read file "C:/hostedtoolcache/windows/Python/3.12.9/x64/tcl/tk8.6/ttk/combobox.tcl": no such file or directory
couldn't read file "C:/hostedtoolcache/windows/Python/3.12.9/x64/tcl/tk8.6/ttk/combobox.tcl": no such file or directory
    while executing
"source -encoding utf-8 [file join $::ttk::library combobox.tcl]	"
    (file "C:/hostedtoolcache/windows/Python/3.12.9/x64/tcl/tk8.6/ttk/ttk.tcl" line 123)
    invoked from within
"source -encoding utf-8 C:/hostedtoolcache/windows/Python/3.12.9/x64/tcl/tk8.6/ttk/ttk.tcl"
    ("uplevel" body line 1)
    invoked from within
"uplevel \#0 [list source -encoding utf-8 $::ttk::library/ttk.tcl]"
    (file "C:/hostedtoolcache/windows/Python/3.12.9/x64/tcl/tk8.6/tk.tcl" line 702)
    invoked from within
"source -encoding utf-8 C:/hostedtoolcache/windows/Python/3.12.9/x64/tcl/tk8.6/tk.tcl"
    ("uplevel" body line 1)
    invoked from within
"uplevel #0 [list source -encoding utf-8 $file]"
```