### PR TITLE
Pin matplotlib and pillow for stable plotting tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,9 @@ pylint==3.3.4
 ## we test that the code is correctly formatted
 black==25.1.0
 isort==6.0.0
+## pinned so pixel-exact plotting tests match the committed reference images
+matplotlib==3.10.9
+pillow==12.2.0
 
 # Docs
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,9 @@ pylint==3.3.4
 ## we test that the code is correctly formatted
 black==25.1.0
 isort==6.0.0
-## pinned so pixel-exact plotting tests match the committed reference images
-matplotlib==3.10.9
-pillow==12.2.0
+## capped below 3.11, whose text rendering changed and broke the pixel-exact
+## plotting tests; an exact pin can't span the 3.9-3.12 CI matrix
+matplotlib<3.11
 
 # Docs
 


### PR DESCRIPTION
## Problem
The `TestPlotting` image-comparison tests compare rendered PNGs against committed reference images pixel-for-pixel. `matplotlib` is unpinned (pulled in transitively) and CI has no pip cache/lockfile, so every run resolves it fresh.

Runs after the **matplotlib 3.11** release resolve to 3.11.x, whose antialiased text rendering shifts subpixel values — 12 plotting tests fail with diffs concentrated on glyph edges (uniform max-abs-diff of 128), i.e. a rendering change, not a data change. Any branch's CI now fails this way regardless of its contents.

## Fix
Cap `matplotlib<3.11`. The reference images render identically under matplotlib 3.9.x and 3.10.x — the last green `main` run installed 3.9.4 on the Python 3.9 leg and 3.10.9 on 3.11/3.12 and passed on both — and only broke at 3.11. A cap (not an exact pin) is required because matplotlib 3.10+ needs Python >=3.10 and cannot install on the 3.9 matrix leg. pillow is left unpinned: PNG is lossless, so pillow's version does not affect the comparison.

## Verification
- Resolves per-Python to exactly what the last green `main` CI run installed (3.9 -> 3.9.4, 3.10+ -> 3.10.9).
- CI on this PR confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)